### PR TITLE
added check for password and also added username to output

### DIFF
--- a/pwned.py
+++ b/pwned.py
@@ -48,4 +48,4 @@ def main():
 
 
 if __name__ == "__main__":
-	sys.exit(main())
+    sys.exit(main())

--- a/pwned.py
+++ b/pwned.py
@@ -33,6 +33,8 @@ def main():
     count_pwned = 0
     credentials = get_credentials()
     for item in credentials:
+        if not item["login"]["password"]:
+            continue
         password = item["login"]["password"].encode("utf-8")
         password_hash = get_hash(password)
         results = get_pwned(password_hash)
@@ -40,10 +42,10 @@ def main():
         if not pwned:
             continue
         count_pwned += 1
-        print(f"{item['name']} has been pwned!")
+        print(f"{item['name']}:{item['login']['username']} has been pwned!")
 
     print(f"{count_pwned} of {len(credentials)} logins have been pwned.")
 
 
 if __name__ == "__main__":
-    sys.exit(main())
+	sys.exit(main())


### PR DESCRIPTION
This corrects the issue that I opened a little bit ago. It simply checks to make sure that the given account actually has a password as apparently, bitwarden does not always include the password object.

I also added the login username to the output when a pwned pass has been found. Since different sites can have multiple username/password combos it helps to know which of those accounts has the compromised password.